### PR TITLE
[CDN-1153] Augment stats with distributions

### DIFF
--- a/statsd.go
+++ b/statsd.go
@@ -116,6 +116,14 @@ func (c *Client) Histogram(bucket string, value interface{}) {
 	c.conn.metric(c.prefix, bucket, value, "h", c.rate, c.tags)
 }
 
+// Distribution sends a distribution value to a bucket.
+func (c *Client) Distribution(bucket string, value interface{}) {
+	if c.skip() {
+		return
+	}
+	c.conn.metric(c.prefix, bucket, value, "d", c.rate, c.tags)
+}
+
 // A Timing is an helper object that eases sending timing values.
 type Timing struct {
 	start time.Time

--- a/statsd_test.go
+++ b/statsd_test.go
@@ -49,6 +49,12 @@ func TestHistogram(t *testing.T) {
 	})
 }
 
+func TestDistribution(t *testing.T) {
+	testOutput(t, "test_dist_key:97|d", func(c *Client) {
+		c.Distribution("test_dist_key", 97)
+	})
+}
+
 func TestNumbers(t *testing.T) {
 	testOutput(t,
 		"test_key:1|g\n"+


### PR DESCRIPTION
This is an extensions to the statsd client that is specific to Datadog and enables the gathering of 'Distribution' metrics.  More information about distribution metrics can be found here:

   https://docs.datadoghq.com/metrics/distributions/

Since this is a non-standard Datadog extension to statsd I looked at their 'official' implementation to determine the byte type used for distributions.  Found it here:
   https://github.com/DataDog/datadog-go/blob/master/statsd/format.go#L12

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/caffeinetv/statsd/1)
<!-- Reviewable:end -->
